### PR TITLE
Migrate to rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cbm"
 version = "0.1.0"
 authors = ["David Simmons <simmons@davidsimmons.com>"]
-edition = '2018'
+edition = '2021'
 license = "MIT/Apache-2.0"
 repository = "https://github.com/simmons/cbm"
 keywords = ["cbm", "commodore", "c64", "d64" ]

--- a/src/bin/cdisk.rs
+++ b/src/bin/cdisk.rs
@@ -315,12 +315,12 @@ fn open_cbm_file(diskimage: &str, filename: &str) -> io::Result<File> {
 }
 
 /// Open a file on a CBM disk image for reading.
-fn open_cbm_reader(diskimage: &str, filename: &str) -> io::Result<Box<Read>> {
+fn open_cbm_reader(diskimage: &str, filename: &str) -> io::Result<Box<dyn Read>> {
     Ok(Box::new(open_cbm_file(diskimage, filename)?.reader()?))
 }
 
 /// Open a file on a CBM disk image for appending.
-fn open_cbm_appender(diskimage: &str, filename: &str) -> io::Result<Box<Write>> {
+fn open_cbm_appender(diskimage: &str, filename: &str) -> io::Result<Box<dyn Write>> {
     Ok(Box::new(open_cbm_file(diskimage, filename)?.writer()?))
 }
 
@@ -338,12 +338,12 @@ fn open_geos_file(diskimage: &str, filename: &str) -> io::Result<GEOSFile> {
 }
 
 /// Open a GEOS file for reading.
-fn open_geos_reader(diskimage: &str, filename: &str) -> io::Result<Box<Read>> {
+fn open_geos_reader(diskimage: &str, filename: &str) -> io::Result<Box<dyn Read>> {
     Ok(Box::new(open_geos_file(diskimage, filename)?.reader()?))
 }
 
 /// Open a file on a CBM disk image for writing.
-fn open_cbm_writer(diskimage: &str, filename: &str, file_type: FileType) -> io::Result<Box<Write>> {
+fn open_cbm_writer(diskimage: &str, filename: &str, file_type: FileType) -> io::Result<Box<dyn Write>> {
     let mut disk = disk::open(diskimage, true)?;
     let file = disk.create_file(&filename.into(), file_type, Scheme::Linear)?;
     let file = match file {
@@ -355,7 +355,7 @@ fn open_cbm_writer(diskimage: &str, filename: &str, file_type: FileType) -> io::
 }
 
 /// Open a file for reading
-fn open_fs_reader(filename: &str) -> io::Result<Box<Read>> {
+fn open_fs_reader(filename: &str) -> io::Result<Box<dyn Read>> {
     if filename == STDINOUT_PSEUDOFILENAME {
         Ok(Box::new(io::stdin()))
     } else {
@@ -364,7 +364,7 @@ fn open_fs_reader(filename: &str) -> io::Result<Box<Read>> {
 }
 
 /// Open a file for writing
-fn open_fs_writer(filename: &str) -> io::Result<Box<Write>> {
+fn open_fs_writer(filename: &str) -> io::Result<Box<dyn Write>> {
     if filename == STDINOUT_PSEUDOFILENAME {
         Ok(Box::new(io::stdout()))
     } else {

--- a/src/disk/block.rs
+++ b/src/disk/block.rs
@@ -11,7 +11,7 @@ use crate::util;
 
 pub const BLOCK_SIZE: usize = 256;
 
-pub type BlockDeviceRef = Rc<RefCell<BlockDevice>>;
+pub type BlockDeviceRef = Rc<RefCell<dyn BlockDevice>>;
 
 pub trait BlockDevice {
     fn check_writability(&self) -> io::Result<()>;
@@ -31,7 +31,7 @@ pub trait BlockDevice {
         Ok(&block[position.offset as usize..position.offset as usize + position.size as usize])
     }
 
-    fn positioned_read(&self, positioned_data: &mut PositionedData) -> io::Result<()> {
+    fn positioned_read(&self, positioned_data: &mut dyn PositionedData) -> io::Result<()> {
         let position = positioned_data.position()?;
         let block = self.sector(position.location)?;
         positioned_data.positioned_read(
@@ -40,7 +40,7 @@ pub trait BlockDevice {
         Ok(())
     }
 
-    fn positioned_write(&mut self, positioned_data: &PositionedData) -> io::Result<()> {
+    fn positioned_write(&mut self, positioned_data: &dyn PositionedData) -> io::Result<()> {
         let position = positioned_data.position()?;
         let block = self.sector_mut(position.location)?;
         positioned_data.positioned_write(
@@ -49,7 +49,7 @@ pub trait BlockDevice {
         Ok(())
     }
 
-    fn dump(&self, writer: &mut Write) -> io::Result<()> {
+    fn dump(&self, writer: &mut dyn Write) -> io::Result<()> {
         let locations = LocationIterator::from_geometry(self.geometry());
         for location in locations {
             writeln!(writer, "")?;

--- a/src/disk/chain.rs
+++ b/src/disk/chain.rs
@@ -155,7 +155,7 @@ impl io::Read for ChainReader {
                 Some(mut block) => {
                     // Copy as much of this block as possible into the caller-provided buffer.
                     let nbytes = block.len().min(buf.len());
-                    &buf[0..nbytes].copy_from_slice(&block[0..nbytes]);
+                    let _ = &buf[0..nbytes].copy_from_slice(&block[0..nbytes]);
                     total_nbytes += nbytes;
 
                     // Reduce the block slice to the unread portion (which may be zero bytes).
@@ -332,7 +332,7 @@ impl io::Write for ChainWriter {
 
             // Copy as much of the caller-provided buffer as possible into the block.
             let nbytes = remaining.min(buf.len());
-            &self.block[offset..offset + nbytes].copy_from_slice(&buf[0..nbytes]);
+            let _ = &self.block[offset..offset + nbytes].copy_from_slice(&buf[0..nbytes]);
             total_nbytes += nbytes;
 
             // Update the block link's indication of used bytes.

--- a/src/disk/d64.rs
+++ b/src/disk/d64.rs
@@ -235,11 +235,11 @@ impl Disk for D64 {
         self.blocks.clone()
     }
 
-    fn blocks_ref(&self) -> ::std::cell::Ref<'_, BlockDevice> {
+    fn blocks_ref(&self) -> ::std::cell::Ref<'_, dyn BlockDevice> {
         self.blocks.borrow()
     }
 
-    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, BlockDevice> {
+    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, dyn BlockDevice> {
         self.blocks.borrow_mut()
     }
 

--- a/src/disk/d71.rs
+++ b/src/disk/d71.rs
@@ -256,11 +256,11 @@ impl Disk for D71 {
         self.blocks.clone()
     }
 
-    fn blocks_ref(&self) -> ::std::cell::Ref<'_, BlockDevice> {
+    fn blocks_ref(&self) -> ::std::cell::Ref<'_, dyn BlockDevice> {
         self.blocks.borrow()
     }
 
-    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, BlockDevice> {
+    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, dyn BlockDevice> {
         self.blocks.borrow_mut()
     }
 

--- a/src/disk/d81.rs
+++ b/src/disk/d81.rs
@@ -270,9 +270,9 @@ impl Disk for D81 {
     }
 
     fn header<'a>(&'a self) -> io::Result<&'a Header> {
-        match &self.header {
-            &Some(ref header) => Ok(&header),
-            &None => Err(DiskError::Unformatted.into()),
+        match self.header {
+            Some(ref header) => Ok(header),
+            None => Err(DiskError::Unformatted.into()),
         }
     }
 

--- a/src/disk/d81.rs
+++ b/src/disk/d81.rs
@@ -261,11 +261,11 @@ impl Disk for D81 {
         self.blocks.clone()
     }
 
-    fn blocks_ref(&self) -> ::std::cell::Ref<'_, BlockDevice> {
+    fn blocks_ref(&self) -> ::std::cell::Ref<'_, dyn BlockDevice> {
         self.blocks.borrow()
     }
 
-    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, BlockDevice> {
+    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, dyn BlockDevice> {
         self.blocks.borrow_mut()
     }
 

--- a/src/disk/directory.rs
+++ b/src/disk/directory.rs
@@ -556,7 +556,7 @@ impl fmt::Debug for DirectoryEntry {
 
 /// We use a boxed type for this instead of just a ChainIterator, so we can add
 /// the GEOS border block to the iteration if needed.
-type DirectoryBlockIterator = Box<Iterator<Item = io::Result<ChainSector>>>;
+type DirectoryBlockIterator = Box<dyn Iterator<Item = io::Result<ChainSector>>>;
 
 /// This iterator will process the entire directory of a disk image and return
 /// a sequence of entries.

--- a/src/disk/directory.rs
+++ b/src/disk/directory.rs
@@ -112,16 +112,16 @@ impl FileAttributes {
             &FileType::Unknown(b) => b,
         };
         if self.unused_bit {
-            byte = byte | FILE_ATTRIB_UNUSED_MASK
+            byte |= FILE_ATTRIB_UNUSED_MASK
         };
         if self.save_with_replace_flag {
-            byte = byte | FILE_ATTRIB_SAVE_WITH_REPLACE_MASK
+            byte |= FILE_ATTRIB_SAVE_WITH_REPLACE_MASK
         };
         if self.locked_flag {
-            byte = byte | FILE_ATTRIB_LOCKED_MASK
+            byte |= FILE_ATTRIB_LOCKED_MASK
         };
         if self.closed_flag {
-            byte = byte | FILE_ATTRIB_CLOSED_MASK
+            byte |= FILE_ATTRIB_CLOSED_MASK
         };
         byte
     }
@@ -228,7 +228,7 @@ impl fmt::Debug for Extra {
 
 /// The extra directory entry bytes used in regular files.  These should all be
 /// unused, so we simply preserve whatever bytes are present.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct LinearExtra {
     pub unused: Vec<u8>, // 9 bytes
 }

--- a/src/disk/error.rs
+++ b/src/disk/error.rs
@@ -94,7 +94,7 @@ impl error::Error for DiskError {
 
     /// For errors which encapsulate another error, allow the caller to fetch
     /// the contained error.
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             _ => None,
         }

--- a/src/disk/error.rs
+++ b/src/disk/error.rs
@@ -104,7 +104,7 @@ impl error::Error for DiskError {
 impl fmt::Display for DiskError {
     /// Provide human-readable descriptions of the errors
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", &self.to_string())
     }
 }
 

--- a/src/disk/error.rs
+++ b/src/disk/error.rs
@@ -4,7 +4,7 @@ use std::io;
 
 /// Errors that can be returned from disk image operations.  These are
 /// generally converted into `io::Error`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DiskError {
     /// Unknown error
     Unknown,

--- a/src/disk/error.rs
+++ b/src/disk/error.rs
@@ -1,5 +1,4 @@
 use std::error;
-use std::error::Error;
 use std::fmt;
 use std::io;
 

--- a/src/disk/geos/file.rs
+++ b/src/disk/geos/file.rs
@@ -137,7 +137,7 @@ impl FileOps for GEOSFile {
         }
     }
 
-    fn details(&self, writer: &mut io::Write, verbosity: usize) -> io::Result<()> {
+    fn details(&self, writer: &mut dyn io::Write, verbosity: usize) -> io::Result<()> {
         if verbosity > 0 {
             if let Some(position) = self.entry().position {
                 writeln!(writer, "Directory position: {}", position)?;
@@ -228,7 +228,7 @@ impl FileOps for GEOSFile {
         Ok(locations)
     }
 
-    fn reader(&self) -> io::Result<Box<Read>> {
+    fn reader(&self) -> io::Result<Box<dyn Read>> {
         match self.vlir {
             Some(_) => Err(DiskError::NonLinearFile.into()),
             None => {
@@ -242,7 +242,7 @@ impl FileOps for GEOSFile {
         }
     }
 
-    fn writer(&self) -> io::Result<Box<io::Write>> {
+    fn writer(&self) -> io::Result<Box<dyn io::Write>> {
         match self.vlir {
             Some(_) => Err(DiskError::NonLinearFile.into()),
             None => Err(DiskError::ReadOnly.into()),

--- a/src/disk/geos/reader.rs
+++ b/src/disk/geos/reader.rs
@@ -212,7 +212,7 @@ impl Read for GEOSReader {
             let bytes = buf.len().min(self.buffer.len());
 
             // Write bytes
-            &mut buf[..bytes].copy_from_slice(&self.buffer[..bytes]);
+            let _ = &mut buf[..bytes].copy_from_slice(&self.buffer[..bytes]);
             bytes_written += bytes;
 
             if bytes == buf.len() {

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -222,7 +222,7 @@ pub trait Disk {
 
         // Write a fresh header
         {
-            let mut header = Header::new(disk_format.header, disk_format, &name, &id);
+            let mut header = Header::new(disk_format.header, disk_format, name, id);
             header.write(self.blocks(), disk_format.header)?;
             self.set_header(Some(header));
         }
@@ -437,7 +437,7 @@ pub trait Disk {
 impl fmt::Display for dyn Disk {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.header() {
-            &Ok(ref header) => {
+            &Ok(header) => {
                 write!(
                     f,
                     "{} \"{:16}\" {} {}",
@@ -540,7 +540,7 @@ impl Geometry {
 
 /// Various fields in CBM DOS are two-byte identifiers which are frequently
 /// shown as Petscii strings.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Id([u8; 2]);
 
 impl Id {

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -79,7 +79,7 @@ impl DiskType {
 
 /// Open a disk image, regardless of whether it is a D64 (1541), D71 (1571), or
 /// D81 (1581) image.
-pub fn open<P: AsRef<Path>>(path: P, writable: bool) -> io::Result<Box<Disk>> {
+pub fn open<P: AsRef<Path>>(path: P, writable: bool) -> io::Result<Box<dyn Disk>> {
     // Try to determine the disk type based on its filename extension.
     match DiskType::from_extension(&path) {
         Some(DiskType::D64) => return Ok(Box::new(d64::D64::open(path, writable)?)),
@@ -139,8 +139,8 @@ pub trait Disk {
     fn disk_format_mut(&mut self) -> io::Result<&mut DiskFormat>;
     fn set_disk_format(&mut self, disk_format: Option<DiskFormat>);
     fn blocks(&self) -> BlockDeviceRef;
-    fn blocks_ref(&self) -> ::std::cell::Ref<BlockDevice>;
-    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, BlockDevice>;
+    fn blocks_ref(&self) -> ::std::cell::Ref<dyn BlockDevice>;
+    fn blocks_ref_mut(&self) -> ::std::cell::RefMut<'_, dyn BlockDevice>;
     fn header(&self) -> io::Result<&Header>;
     fn header_mut(&mut self) -> io::Result<&mut Header>;
     fn set_header(&mut self, header: Option<Header>);
@@ -404,7 +404,7 @@ pub trait Disk {
     }
 
     /// Write a hex dump of the disk image to the provided writer.
-    fn dump(&mut self, writer: &mut Write) -> io::Result<()> {
+    fn dump(&mut self, writer: &mut dyn Write) -> io::Result<()> {
         self.blocks_ref().dump(writer)
     }
 
@@ -434,7 +434,7 @@ pub trait Disk {
     }
 }
 
-impl fmt::Display for Disk {
+impl fmt::Display for dyn Disk {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.header() {
             &Ok(ref header) => {
@@ -453,7 +453,7 @@ impl fmt::Display for Disk {
     }
 }
 
-impl fmt::Debug for Disk {
+impl fmt::Debug for dyn Disk {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Read a fresh header so we can return a useful error condition should
         // it not be readable.
@@ -465,7 +465,7 @@ impl fmt::Debug for Disk {
     }
 }
 
-impl<'a> IntoIterator for &'a Disk {
+impl<'a> IntoIterator for &'a dyn Disk {
     type Item = io::Result<DirectoryEntry>;
     type IntoIter = DirectoryIterator;
 

--- a/src/disk/validation.rs
+++ b/src/disk/validation.rs
@@ -58,7 +58,7 @@ impl fmt::Display for ValidationError {
                 location, filename1, filename2
             ),
             FileScanError(ref e, ref filename) => write!(f, "Error scanning {:?}: {}", filename, e),
-            _ => f.write_str(self.description()),
+            _ => f.write_str(&self.to_string()),
         }
     }
 }

--- a/src/disk/validation.rs
+++ b/src/disk/validation.rs
@@ -1,7 +1,6 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::error;
-use std::error::Error;
 use std::fmt;
 use std::io;
 use std::iter::FromIterator;

--- a/src/petscii.rs
+++ b/src/petscii.rs
@@ -89,7 +89,7 @@ fn petscii_to_unicode_string(petscii: &[u8]) -> String {
 /// Commodore's 8-bit computers used an unusual variant of ASCII commonly known as "PETSCII".
 /// A PETSCII string can be represented by this `Petscii` struct, and its functions help handle
 /// PETSCII strings and perform lossy conversions between PETSCII and Unicode.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Petscii(Vec<u8>);
 
 impl Petscii {
@@ -106,7 +106,7 @@ impl Petscii {
                 break;
             }
         }
-        Petscii((&bytes[..end]).to_owned())
+        Petscii((bytes[..end]).to_owned())
     }
 
     /// We only translate Unicode code points that happen to be present in our
@@ -180,7 +180,7 @@ impl<'a> From<&'a str> for Petscii {
 
 impl AsRef<Petscii> for Petscii {
     fn as_ref(&self) -> &Petscii {
-        &self
+        self
     }
 }
 
@@ -234,7 +234,7 @@ impl<'a> IntoIterator for &'a Petscii {
     type Item = &'a u8;
     type IntoIter = ::std::slice::Iter<'a, u8>;
     fn into_iter(self) -> Self::IntoIter {
-        (&self.0).into_iter()
+        (self.0).iter()
     }
 }
 

--- a/src/petscii.rs
+++ b/src/petscii.rs
@@ -145,7 +145,7 @@ impl Petscii {
         if src_len > dst_len {
             return Err(());
         } else {
-            &bytes[..src_len].copy_from_slice(&self.0);
+            let _ = &bytes[..src_len].copy_from_slice(&self.0);
             for i in src_len..dst_len {
                 bytes[i] = pad_byte;
             }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -40,7 +40,7 @@ pub fn hexdump(
                 f,
                 "{}",
                 match *b {
-                    c @ 0x20...0x7E => c as char,
+                    c @ 0x20..=0x7E => c as char,
                     _ => '.',
                 }
             )?;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -12,10 +12,10 @@ pub fn hexdump(
     if buffer.len() == 0 {
         // For a zero-length buffer, at least print an offset instead of
         // nothing.
-        r#try!(write!(f, "{}{:04x}: ", prefix, 0));
+        write!(f, "{}{:04x}: ", prefix, 0)?;
     }
     while offset < buffer.len() {
-        r#try!(write!(f, "{}{:04x}: ", prefix, offset));
+        write!(f, "{}{:04x}: ", prefix, offset)?;
 
         // Determine row byte range
         let next_offset = offset + COLUMNS;
@@ -28,27 +28,27 @@ pub fn hexdump(
 
         // Print hex representation
         for b in row {
-            r#try!(write!(f, "{:02x} ", b));
+            write!(f, "{:02x} ", b)?;
         }
         for _ in 0..padding {
-            r#try!(write!(f, "   "));
+            write!(f, "   ")?;
         }
 
         // Print ASCII representation
         for b in row {
-            r#try!(write!(
+            write!(
                 f,
                 "{}",
                 match *b {
                     c @ 0x20...0x7E => c as char,
                     _ => '.',
                 }
-            ));
+            )?;
         }
 
         offset += COLUMNS;
         if offset < buffer.len() {
-            r#try!(writeln!(f, ""));
+            writeln!(f, "")?;
         }
     }
     Ok(())

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,7 +9,7 @@ pub fn hexdump(
 ) -> std::result::Result<(), std::fmt::Error> {
     const COLUMNS: usize = 16;
     let mut offset: usize = 0;
-    if buffer.len() == 0 {
+    if buffer.is_empty() {
         // For a zero-length buffer, at least print an offset instead of
         // nothing.
         write!(f, "{}{:04x}: ", prefix, 0)?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -34,7 +34,7 @@ fn random_name(rng: &mut impl Rng) -> Petscii {
     Petscii::from_bytes(&bytes)
 }
 
-fn random_available_name(rng: &mut impl Rng, disk: &Box<Disk>) -> Petscii {
+fn random_available_name(rng: &mut impl Rng, disk: &Box<dyn Disk>) -> Petscii {
     loop {
         let name = random_name(rng);
 
@@ -65,7 +65,7 @@ fn random_file_type(rng: &mut impl Rng) -> FileType {
     LINEAR_FILE_TYPES[rng.gen_range(0, LINEAR_FILE_TYPES.len())]
 }
 
-fn new_disk(mut rng: &mut impl Rng, disk_type: &DiskType) -> Box<Disk> {
+fn new_disk(mut rng: &mut impl Rng, disk_type: &DiskType) -> Box<dyn Disk> {
     let name = random_name(&mut rng);
     let id = random_id(&mut rng);
     match disk_type {
@@ -95,7 +95,7 @@ struct RandomFile {
 }
 
 impl RandomFile {
-    fn new(mut rng: &mut XorShiftRng, disk: &Box<Disk>) -> RandomFile {
+    fn new(mut rng: &mut XorShiftRng, disk: &Box<dyn Disk>) -> RandomFile {
         let name = random_available_name(&mut rng, &disk);
         let size: usize = rng.gen_range(MIN_FILE_SIZE, MAX_FILE_SIZE);
         let file_type = random_file_type(&mut rng);
@@ -113,7 +113,7 @@ impl RandomFile {
         (self.size + CONTENT_BYTES_PER_BLOCK - 1) / CONTENT_BYTES_PER_BLOCK
     }
 
-    fn write(&self, disk: &mut Box<Disk>) -> io::Result<()> {
+    fn write(&self, disk: &mut Box<dyn Disk>) -> io::Result<()> {
         let file = disk.create_file(&self.name, self.file_type, Scheme::Linear)?;
         let mut writer = file.writer()?;
         writer.write_all(&self.contents)?;
@@ -121,7 +121,7 @@ impl RandomFile {
         Ok(())
     }
 
-    fn verify(&self, disk: &Box<Disk>) -> io::Result<()> {
+    fn verify(&self, disk: &Box<dyn Disk>) -> io::Result<()> {
         // Read file.
         let file = disk.open_file(&self.name)?;
         let mut reader = file.reader()?;
@@ -151,7 +151,7 @@ impl fmt::Debug for RandomFile {
     }
 }
 
-fn verify_disk_state(disk: &Box<Disk>, files: &Vec<RandomFile>) -> io::Result<()> {
+fn verify_disk_state(disk: &Box<dyn Disk>, files: &Vec<RandomFile>) -> io::Result<()> {
     // Validate disk image
     disk.validate().unwrap();
     // Confirm blocks free


### PR DESCRIPTION
This fixes a number warnings and updates Rust from 2018 to 2021.