### PR TITLE
Fix typos in documentation comments

### DIFF
--- a/src/disk/bam.rs
+++ b/src/disk/bam.rs
@@ -22,7 +22,7 @@ impl BamFormat {
 }
 
 /// BAM can be stored in one or more sections, depending on the disk image
-/// format.  Each sections stores BAM entries for a particular range of tracks.
+/// format. Each section stores BAM entries for a particular range of tracks.
 pub struct BamSection {
     /// The track and sector where this section's bitmaps are stored.
     pub bitmap_location: Location,

--- a/src/disk/file.rs
+++ b/src/disk/file.rs
@@ -46,11 +46,11 @@ pub enum Scheme {
 /// A File represents a file that has been opened from a CBM disk image.
 ///
 /// In the 1980's, non-linear file structures were more common, and such files
-/// can't directly map to our sdfsdfsdf modern notion of files as a single
-/// sequence of bytes.  This makes it impractical to implement simple Read and
-/// Write traits.  Our approach is to allow the caller to open a `File`, which
-/// itself is an enum containing more specialized types which map to various
-/// file layout schemes.
+/// can't directly map to our modern notion of files as a single sequence of
+/// bytes.  This makes it impractical to implement simple Read and Write traits.
+/// Our approach is to allow the caller to open a `File`, which itself is an
+/// enum containing more specialized types which map to various file layout
+/// schemes.
 pub enum File {
     /// The file is a regular, linear file that can be fully read from the
     /// beginning to the end. Most CBM PRG, SEQ, and USR files fall into
@@ -62,7 +62,6 @@ pub enum File {
     /// entry, and index information in a number of "side sectors" to allow
     /// random access of specific records.  The contents may be accessed
     /// using the contained `RelativeFile`.
-    /// `RelativeFile` object.
     Relative(RelativeFile),
     /// The file is a GEOS sequential file.  In addition to the linear byte
     /// stream, this scheme stores additional GEOS-specific metadata in an
@@ -88,7 +87,7 @@ pub trait FileOps {
     /// Delete the file represented by this object.
     fn delete(&mut self) -> io::Result<()>;
     /// Return the number of records that this file offers.  This will always
-    /// be 1 for `Linear` or `GEOSSequential`.)
+    /// be 1 for `Linear` or `GEOSSequential`.
     fn record_count(&self) -> io::Result<usize>;
     /// Read an entire record into memory and return it.
     fn record(&self, index: usize) -> io::Result<Vec<u8>>;

--- a/src/disk/format.rs
+++ b/src/disk/format.rs
@@ -21,6 +21,7 @@ pub struct Track {
 
 #[derive(Clone)]
 pub struct DiskFormat {
+    /// The directory track used for this format.
     pub directory_track: u8,
     /// This should be pointed to from the header sector, but the various image
     /// format documents say not to trust it.
@@ -43,7 +44,7 @@ pub struct DiskFormat {
     /// non-standard methods.
     pub last_nonstandard_track: u8,
     /// The default interleave.  This may be changed on a per-image basis to
-    /// support other layout varients such as GEOS-formatted disks.
+    /// support other layout variants such as GEOS-formatted disks.
     pub interleave: u8,
     /// Drives may use a special interleave for directory tracks, since
     /// scanning directories usually doesn't involve I/O between the host

--- a/src/disk/geos/mod.rs
+++ b/src/disk/geos/mod.rs
@@ -188,7 +188,7 @@ impl Display for GEOSFileType {
 
 use std::ascii;
 
-/// GEOS uses regular ASCII to store text, as opposed to Petscii or Unicode.
+/// GEOS uses regular ASCII to store text, as opposed to PETSCII or Unicode.
 
 pub struct GEOSString {
     data: Vec<u8>,

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -47,7 +47,6 @@
 //!    same value used in the diskette format type: The 1541/1571 ROMs will
 //!    write `0x41` ("A"), and the 1581/C65 ROMs will write `0x44` ("D").
 //!
-//!
 //! Note that the names for these fields can vary. I'm choosing to use the
 //! terminology found in the 1540 ROM source, since it makes a clear distinction
 //! between the format type as written to offset `0x02` ("diskette format type")
@@ -363,8 +362,8 @@ pub trait Disk {
         directory::next_free_directory_entry(self)
     }
 
-    /// Write the the provide directory entry to disk, using the same slot as
-    /// it was originally read from.
+    /// Write the provided directory entry to disk, using the same slot as it was
+    /// originally read from.
     fn write_directory_entry(&mut self, entry: &DirectoryEntry) -> io::Result<()> {
         let mut blocks = self.blocks_ref_mut();
         blocks.positioned_write(entry)?;

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -4,7 +4,6 @@ pub const SPRITE_HEIGHT: usize = 21;
 
 /// Store the data associated with a sprite image.  Multicolor sprites are not
 /// supported at this time.
-
 pub struct Sprite {
     data: Vec<u8>,
 }


### PR DESCRIPTION
_Note: This is a stacked PR based on #5._
