### PR TITLE
Refactor cdisk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 memmap = "0.6.2"
-clap = "~2.31.2"
+clap = "2.34.0"
 
 [dev-dependencies]
 rand = "0.5.2"

--- a/src/bin/cdisk.rs
+++ b/src/bin/cdisk.rs
@@ -20,7 +20,7 @@ const STDINOUT_PSEUDOFILENAME: &str = "-";
 fn main() {
     // Parse command-line arguments
     let app = App::new("Commodore Disk Image Utility")
-        .version("0.1.0")
+        .version(clap::crate_version!())
         .about("Read, write, and understand D64/D71/D81 disk images.")
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(Arg::with_name("diskimage").required(true))

--- a/src/bin/cdisk.rs
+++ b/src/bin/cdisk.rs
@@ -10,12 +10,12 @@ use cbm::disk::{self, D64, D71, D81, DiskType};
 use cbm::Petscii;
 
 // Possible exit codes
-static _EXIT_SUCCESS: i32 = 0;
-static EXIT_FAILURE: i32 = 1;
+const _EXIT_SUCCESS: i32 = 0;
+const EXIT_FAILURE: i32 = 1;
 
 /// If a dash is specified for a filename, this indicates that the user wants
 /// to read from standard input or write to standard output.
-static STDINOUT_PSEUDOFILENAME: &str = "-";
+const STDINOUT_PSEUDOFILENAME: &str = "-";
 
 fn main() {
     // Parse command-line arguments

--- a/src/bin/cdisk.rs
+++ b/src/bin/cdisk.rs
@@ -302,9 +302,7 @@ fn cmd_bam_edit(
         }
     }
     // Write the updated BAM
-    bam.flush()?;
-
-    Ok(())
+    bam.flush()
 }
 
 /// Open an existing CBM file from the specified disk image for reading.
@@ -381,8 +379,7 @@ fn cmd_read(
     let mut reader = open_cbm_reader(diskimage, source_filename)?;
     let mut writer = open_fs_writer(destination_filename)?;
     io::copy(&mut reader, &mut writer)?;
-    writer.flush()?;
-    Ok(())
+    writer.flush()
 }
 
 fn cmd_write(
@@ -395,8 +392,7 @@ fn cmd_write(
     let mut reader = open_fs_reader(source_filename)?;
     let mut writer = open_cbm_writer(diskimage, destination_filename, file_type)?;
     io::copy(&mut reader, &mut writer)?;
-    writer.flush()?;
-    Ok(())
+    writer.flush()
 }
 
 fn cmd_append(
@@ -408,8 +404,7 @@ fn cmd_append(
     let mut reader = open_fs_reader(source_filename)?;
     let mut writer = open_cbm_appender(diskimage, destination_filename)?;
     io::copy(&mut reader, &mut writer)?;
-    writer.flush()?;
-    Ok(())
+    writer.flush()
 }
 
 fn cmd_geosread(
@@ -421,8 +416,7 @@ fn cmd_geosread(
     let mut reader = open_geos_reader(diskimage, source_filename)?;
     let mut writer = open_fs_writer(destination_filename)?;
     io::copy(&mut reader, &mut writer)?;
-    writer.flush()?;
-    Ok(())
+    writer.flush()
 }
 
 fn cmd_create(diskimage: &str) -> io::Result<()> {
@@ -442,8 +436,7 @@ fn cmd_create(diskimage: &str) -> io::Result<()> {
         .create_new(true)
         .open(diskimage)?;
     io::copy(&mut FillReader::new(0x00, geometry.size()), &mut file)?;
-    file.flush()?;
-    Ok(())
+    file.flush()
 }
 
 fn cmd_dir(diskimage: &str, verbosity: u64) -> io::Result<()> {
@@ -473,8 +466,7 @@ fn cmd_format(diskimage: &str, name: &str, id: &str) -> io::Result<()> {
     let id_bytes: &[u8] = id.as_bytes();
 
     let mut disk = disk::open(diskimage, true)?;
-    disk.write_format(&name.into(), &id_bytes.into())?;
-    Ok(())
+    disk.write_format(&name.into(), &id_bytes.into())
 }
 
 fn cmd_rename(diskimage: &str, original_filename: &str, new_filename: &str) -> io::Result<()> {
@@ -497,8 +489,7 @@ fn cmd_dump(diskimage: &str, filename: Option<&str>) -> io::Result<()> {
         }
         None => disk.dump(&mut io::stdout())?,
     }
-    io::stdout().flush()?;
-    Ok(())
+    io::stdout().flush()
 }
 
 fn cmd_validate(diskimage: &str) -> io::Result<()> {


### PR DESCRIPTION
- Automatically extract crate version for cdisk version
- Change `static` to `const`. See recommendation [here](https://rust-lang.github.io/rfcs/0246-const-vs-static.html).
- Removed unneeded `Ok()`'s
- Bump Clap to latest v2

Later, it might be useful to re-factor for clap v4 using the (now [recommended](https://docs.rs/clap/latest/clap/_faq/index.html#when-should-i-use-the-builder-vs-derive-apis)) `derive` interface, and also avoid `process::exit()` which uses platform-specific return codes and skips cleanups.